### PR TITLE
Fixed intermittent failure of tests

### DIFF
--- a/microservices-v2-master/social-multiplication/src/test/java/microservices/book/multiplication/service/RandomGeneratorServiceImplTest.java
+++ b/microservices-v2-master/social-multiplication/src/test/java/microservices/book/multiplication/service/RandomGeneratorServiceImplTest.java
@@ -27,7 +27,7 @@ public class RandomGeneratorServiceImplTest {
 
         // then all of them should be between 11 and 100
         // because we want a middle-complexity calculation
-        assertThat(randomFactors).containsOnlyElementsOf(IntStream.range(11, 100)
+        assertThat(randomFactors).isSubsetOf(IntStream.range(11, 100)
                 .boxed().collect(Collectors.toList()));
     }
 

--- a/microservices-v2-master/social-multiplication/src/test/java/microservices/book/multiplication/service/RandomGeneratorServiceTest.java
+++ b/microservices-v2-master/social-multiplication/src/test/java/microservices/book/multiplication/service/RandomGeneratorServiceTest.java
@@ -28,7 +28,7 @@ public class RandomGeneratorServiceTest {
 
         // then all of them should be between 11 and 100
         // because we want a middle-complexity calculation
-        assertThat(randomFactors).containsOnlyElementsOf(IntStream.range(11, 100)
+        assertThat(randomFactors).isSubsetOf(IntStream.range(11, 100)
                 .boxed().collect(Collectors.toList()));
     }
 


### PR DESCRIPTION
containsOnlyElementsOf will fail intermittently when all the numbers
from 11 to 100 are not generated in the loop. For e.g. if number 11 is
not randomly generated in the 1000 times loop then the assertion
containsOnlyElementsOf will fail. The correct assertion is isSubsetOf.